### PR TITLE
setFinalPath must be public

### DIFF
--- a/library/src/com/levelupstudio/logutils/FileLogger.java
+++ b/library/src/com/levelupstudio/logutils/FileLogger.java
@@ -536,7 +536,7 @@ public class FileLogger {
 		}
 	}
 
-	void setFinalPath(File finalPath) {
+	public void setFinalPath(File finalPath) {
 		this.finalPath = finalPath;
 	}
 }


### PR DESCRIPTION
`setFinalPath` must be public, otherwise it's impossible to collect logs.